### PR TITLE
Fixed gaussian-posteriors example smc import

### DIFF
--- a/worksheets/gaussian-posteriors.clj
+++ b/worksheets/gaussian-posteriors.clj
@@ -18,7 +18,7 @@
             [anglican.stat :as s])
   (:use clojure.repl
         [anglican 
-          core runtime emit 
+          core runtime emit smc
           [state :only [get-predicts get-log-weight set-log-weight]]
           [inference :only [collect-by equalize]]]))
 ;; @@


### PR DESCRIPTION
`gaussian-posteriors.clj` example was missing smc import.